### PR TITLE
Add basic auth via requests library

### DIFF
--- a/metabase_api/metabase_api.py
+++ b/metabase_api/metabase_api.py
@@ -3,13 +3,14 @@ import getpass
 
 class Metabase_API():
   
-  def __init__(self, domain, email, password=None):
+  def __init__(self, domain, email, password=None, basic_auth=False):
     
     self.domain = domain
     self.email = email
     self.password = getpass.getpass(prompt='Please enter your password: ') if password is None else password
     self.session_id = None
     self.header = None
+    self.auth = (self.email, self.password) if basic_auth else None
     self.authenticate()
   
   
@@ -18,7 +19,7 @@ class Metabase_API():
     conn_header = {'username':self.email,
                    'password':self.password}
 
-    res = requests.post(self.domain + '/api/session', json = conn_header)
+    res = requests.post(self.domain + '/api/session', json = conn_header, auth=self.auth)
     if not res.ok:
       raise Exception(res)
     

--- a/metabase_api/metabase_api.py
+++ b/metabase_api/metabase_api.py
@@ -19,7 +19,7 @@ class Metabase_API():
     conn_header = {'username':self.email,
                    'password':self.password}
 
-    res = requests.post(self.domain + '/api/session', json = conn_header, auth=self.auth)
+    res = requests.post(self.domain + '/api/session', json=conn_header, auth=self.auth)
     if not res.ok:
       raise Exception(res)
     
@@ -29,7 +29,7 @@ class Metabase_API():
   
   def validate_session(self):
     """Get a new session ID if the previous one has expired"""
-    res = requests.get(self.domain + '/api/user/current', headers = self.header, auth=self.auth)
+    res = requests.get(self.domain + '/api/user/current', headers=self.header, auth=self.auth)
     
     if res.ok:  # 200
       return True

--- a/metabase_api/metabase_api.py
+++ b/metabase_api/metabase_api.py
@@ -29,7 +29,7 @@ class Metabase_API():
   
   def validate_session(self):
     """Get a new session ID if the previous one has expired"""
-    res = requests.get(self.domain + '/api/user/current', headers = self.header)
+    res = requests.get(self.domain + '/api/user/current', headers = self.header, auth=self.auth)
     
     if res.ok:  # 200
       return True
@@ -46,26 +46,26 @@ class Metabase_API():
   
   def get(self, endpoint, **kwargs):
     self.validate_session()
-    res = requests.get(self.domain + endpoint, headers=self.header, **kwargs)
+    res = requests.get(self.domain + endpoint, headers=self.header, **kwargs, auth=self.auth)
     return res.json() if res.ok else False
   
   
   def post(self, endpoint, **kwargs):
     self.validate_session()
-    res = requests.post(self.domain + endpoint, headers=self.header, **kwargs)
+    res = requests.post(self.domain + endpoint, headers=self.header, **kwargs, auth=self.auth)
     return res.json() if res.ok else False
   
   
   def put(self, endpoint, **kwargs):
     """Used for updating objects (cards, dashboards, ...)"""
     self.validate_session()
-    res = requests.put(self.domain + endpoint, headers=self.header, **kwargs)
+    res = requests.put(self.domain + endpoint, headers=self.header, **kwargs, auth=self.auth)
     return res.status_code
   
   
   def delete(self, endpoint, **kwargs):
     self.validate_session()
-    res = requests.delete(self.domain + endpoint, headers=self.header, **kwargs)
+    res = requests.delete(self.domain + endpoint, headers=self.header, **kwargs, auth=self.auth)
     return res.status_code
   
   

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,9 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/vvaezian/metabase_api_python",
     packages=setuptools.find_packages(),
+    install_requires=[
+        "requests",
+    ],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Requests can do basic auth out of the box.

```python
requests.get('https://api.github.com/user', auth=('user', 'pass'))
```

This works also with POST requests.

Documentation: https://2.python-requests.org/en/master/user/authentication/#basic-authentication
